### PR TITLE
Change popup title and tagline to Mate.ai in Spanish

### DIFF
--- a/extension/popup.html
+++ b/extension/popup.html
@@ -3,7 +3,7 @@
 <html>
 
 <head>
-  <title>TranscripTonic</title>
+  <title>Mate.ai</title>
   <style>
     @import url("https://fonts.googleapis.com/css2?family=SUSE:wght@400;700&display=swap");
 
@@ -136,9 +136,9 @@
     <div class="header">
       <div class="header-content">
         <div class="header-text">
-          <h1>TranscripTonic</h1>
+          <h1>Mate.ai</h1>
           <p class="header-description">
-            Simple Google Meet transcripts. Private and open source.
+            Transcripción sencilla de Google Meet. Privada y de código abierto.
           </p>
         </div>
         <img class="logo" src="./icon.png" alt="Extension icon" />


### PR DESCRIPTION
## Summary
- update extension popup title
- switch header text and description to Spanish wording

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_683ee672ffe88329bf75195eda912bd5